### PR TITLE
Make James.listen work with no arguments like in the examples

### DIFF
--- a/lib/james.rb
+++ b/lib/james.rb
@@ -39,7 +39,7 @@ module James
 
   # Start listening.
   #
-  def self.listen options
+  def self.listen options = {}
     controller.listen options
   end
 


### PR DESCRIPTION
In the examples, you have:

``` ruby
require 'rubygems'
require 'james'

# Your dialog goes here.

# This is needed to start James.
#
James.listen
```

Except that James.listen expects an argument to be passed so it can then pass it to James::Controller.instance. 

In turn, James::Controller.instance does supply the default value for its argument.

I'm not sure if you meant for only James.listen to have a default value or both. In either case, this patch makes the example code work.
